### PR TITLE
Modify AWS Amplify deploy configuration

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,10 +4,10 @@ applications:
       phases:
         preBuild:
           commands:
-            - yarn install
+            - npm install
         build:
           commands:
-            - yarn run build
+            - npm run build
       artifacts:
         baseDirectory: build
         files:

--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,18 @@
+version: 1
+applications:
+  - frontend:
+      phases:
+        preBuild:
+          commands:
+            - yarn install
+        build:
+          commands:
+            - yarn run build
+      artifacts:
+        baseDirectory: build
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - node_modules/**/*
+    appRoot: ui/hockey-teeth


### PR DESCRIPTION
Adds a script to override AWS Amplify's default deploy configuration. Changes `yarn` &rarr; `npm`